### PR TITLE
fix: Handle syntax errors in required file

### DIFF
--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -79,12 +79,13 @@ do
       if #found > 0 then
         local f, err = loadfile(found[1])
 
+        if f == nil then return err end
         local modpath = found[1]
         M.cache[name] = {modpath, hash(modpath), string.dump(f)}
         log('Creating cache for module', name)
         M.dirty = true
 
-        return f or error(err)
+        return f
       end
     end
     return nil


### PR DESCRIPTION
If the required file has syntax errors then loadfile will return
nil, error. That nil is directly passed to string.dump which
throws a nil error and the syntax error is lost.

This  adds a check so that doesn't happen

A simple way test is to have a file with a syntax error
like
```lua
print("hello"
```

And try to require it.

@lewis6991 this is the issue that I mentioned earlier in matrix.