### PR TITLE
Introduce cachepack module to optionally replace mpack usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ This plugin does several things to speed up `require` in Lua.
 
 This is done by using `loadstring` to compile the Lua modules to bytecode and stores them in a cache file. This also has the benefit of avoiding Neovim's expensive module loader which uses `nvim_get_runtime_file()`. The cache is invalidated using the modified time of each modules file path.
 
-**Note**: [mpack](https://luarocks.org/modules/tarruda/mpack) is required for reading and writing of the cache file. Regular Neovim builds will have this built in, however if your build hasn't then you should be able to install it via [packer](https://github.com/wbthomason/packer.nvim), see installation details below.
-
 The cache file is located in `$XDG_CACHE_HOME/nvim/luacache`.
 
 ### Reduces `runtimepath` during `require`
@@ -37,14 +35,6 @@ Neovim currently places its own loader for searching runtime files at the front 
 -- Is using a standard Neovim install, i.e. built from source or using a
 -- provided appimage.
 use 'lewis6991/impatient.nvim'
-
--- If your Neovim install doesn't include mpack, e.g. if installed via
--- Homebrew, then you need to also install mpack from luarocks.
--- There is an existing issue with luarocks on macOS where `luarocks install` is using a different version of lua.
--- @see: https://github.com/wbthomason/packer.nvim/issues/180
--- Make sure to add this on top of your plugins.lua to resolve this
-vim.fn.setenv("MACOSX_DEPLOYMENT_TARGET", "10.15")
-use {'lewis6991/impatient.nvim', rocks = 'mpack'}
 ```
 
 ## Setup

--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -2,6 +2,8 @@ local vim = vim
 local api = vim.api
 local uv = vim.loop
 
+local use_cachepack = true
+
 local get_option, set_option = api.nvim_get_option, api.nvim_set_option
 local get_runtime_file = api.nvim_get_runtime_file
 
@@ -33,7 +35,7 @@ local function load_mpack()
   return require('mpack')
 end
 
-local mpack = load_mpack()
+local mpack = (use_cachepack and require('impatient.cachepack')) or load_mpack()
 
 local function log(...)
   M.log[#M.log+1] = table.concat({string.format(...)}, ' ')
@@ -186,7 +188,9 @@ end
 function M.save_cache()
   if M.dirty then
     log('Updating cache file: %s', M.path)
-    io.open(M.path, 'wb'):write(mpack.pack(M.cache))
+    local f = io.open(M.path, 'w+b')
+    f:write(mpack.pack(M.cache))
+    f:flush()
     M.dirty = false
   end
 end

--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -13,9 +13,11 @@ local M = {
   profile = nil,
   dirty = false,
   path = vim.fn.stdpath('cache')..'/luacache',
-  use_cachepack = true,
+  used_mpack = true,
   log = {}
 }
+
+_G.use_cachepack = _G.use_cachepack ~= false
 
 _G.__luacache = M
 
@@ -34,7 +36,7 @@ local function load_mpack()
   return require('mpack')
 end
 
-local mpack = (M.use_cachepack and require('impatient.cachepack')) or load_mpack()
+local mpack = (_G.use_cachepack and require('impatient.cachepack')) or load_mpack()
 
 local function log(...)
   M.log[#M.log+1] = table.concat({string.format(...)}, ' ')

--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -13,7 +13,6 @@ local M = {
   profile = nil,
   dirty = false,
   path = vim.fn.stdpath('cache')..'/luacache',
-  used_mpack = true,
   log = {}
 }
 

--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -2,8 +2,6 @@ local vim = vim
 local api = vim.api
 local uv = vim.loop
 
-local use_cachepack = true
-
 local get_option, set_option = api.nvim_get_option, api.nvim_set_option
 local get_runtime_file = api.nvim_get_runtime_file
 
@@ -15,6 +13,7 @@ local M = {
   profile = nil,
   dirty = false,
   path = vim.fn.stdpath('cache')..'/luacache',
+  use_cachepack = true,
   log = {}
 }
 
@@ -35,7 +34,7 @@ local function load_mpack()
   return require('mpack')
 end
 
-local mpack = (use_cachepack and require('impatient.cachepack')) or load_mpack()
+local mpack = (M.use_cachepack and require('impatient.cachepack')) or load_mpack()
 
 local function log(...)
   M.log[#M.log+1] = table.concat({string.format(...)}, ' ')

--- a/lua/impatient/cachepack.lua
+++ b/lua/impatient/cachepack.lua
@@ -49,7 +49,6 @@ function InputBuffer.read_string(buf)
 end
 
 function M.pack(cache)
-  _G.__luacache.used_mpack = false
   local total_keys = vim.tbl_count(cache)
   local buf = OutputBuffer.create()
 
@@ -65,7 +64,6 @@ function M.pack(cache)
 end
 
 function M.unpack(str)
-  _G.__luacache.used_mpack = false
   if str == nil or #str == 0 then
     return {}
   end

--- a/lua/impatient/cachepack.lua
+++ b/lua/impatient/cachepack.lua
@@ -6,26 +6,16 @@ local M = {}
 local c_double = ffi.typeof("double[1]")
 local sizeof_c_double = ffi.sizeof("double")
 
-local OutputBuffer = {}
-
-function OutputBuffer.create() return {} end
-
-function OutputBuffer.write_number(buf, num)
+local function write_number(buf, num)
   buf[#buf+1] = ffi.string(c_double(num), sizeof_c_double)
 end
 
-function OutputBuffer.write_string(buf, str)
-  OutputBuffer.write_number(buf, #str)
+local function write_string(buf, str)
+  write_number(buf, #str)
   buf[#buf+1] = str
 end
 
-function OutputBuffer.to_string(buf)
-  return table.concat(buf)
-end
-
-local InputBuffer = {}
-
-function InputBuffer.create(str)
+function create_input_buffer(str)
   return {
     ptr = ffi.new("const char[?]", #str, str),
     pos = 0,
@@ -33,15 +23,15 @@ function InputBuffer.create(str)
   }
 end
 
-function InputBuffer.read_number(buf)
+function read_number(buf)
   if (buf.size < buf.pos) then error("buffer access violation") end
   local res = ffi.cast("double*", buf.ptr + buf.pos)[0]
   buf.pos = buf.pos + sizeof_c_double
   return res
 end
 
-function InputBuffer.read_string(buf)
-  local len = InputBuffer.read_number(buf)
+function read_string(buf)
+  local len = read_number(buf)
   local res = ffi.string(buf.ptr + buf.pos, len)
   buf.pos = buf.pos + len
 
@@ -50,17 +40,17 @@ end
 
 function M.pack(cache)
   local total_keys = vim.tbl_count(cache)
-  local buf = OutputBuffer.create()
+  local buf = {}
 
-  OutputBuffer.write_number(buf, total_keys)
+  write_number(buf, total_keys)
   for k,v in pairs(cache) do
-    OutputBuffer.write_string(buf, k)
-    OutputBuffer.write_string(buf, v[1] or "")
-    OutputBuffer.write_number(buf, v[2] or 0)
-    OutputBuffer.write_string(buf, v[3] or "")
+    write_string(buf, k)
+    write_string(buf, v[1] or "")
+    write_number(buf, v[2] or 0)
+    write_string(buf, v[3] or "")
   end
 
-  return OutputBuffer.to_string(buf)
+  return table.concat(buf)
 end
 
 function M.unpack(str)
@@ -68,18 +58,17 @@ function M.unpack(str)
     return {}
   end
 
-  local buf = InputBuffer.create(str)
+  local buf = create_input_buffer(str)
   local cache = {}
 
-  local total_keys = InputBuffer.read_number(buf)
+  local total_keys = read_number(buf)
   for _ = 1, total_keys do
-    local k = InputBuffer.read_string(buf)
-    local v = {
-      InputBuffer.read_string(buf),
-      InputBuffer.read_number(buf),
-      InputBuffer.read_string(buf)
+    local k = read_string(buf)
+    cache[k] = {
+      read_string(buf),
+      read_number(buf),
+      read_string(buf)
     }
-    cache[k] = v
   end
 
   return cache

--- a/lua/impatient/cachepack.lua
+++ b/lua/impatient/cachepack.lua
@@ -49,6 +49,7 @@ function InputBuffer.read_string(buf)
 end
 
 function M.pack(cache)
+  _G.__luacache.used_mpack = false
   local total_keys = vim.tbl_count(cache)
   local buf = OutputBuffer.create()
 
@@ -64,6 +65,7 @@ function M.pack(cache)
 end
 
 function M.unpack(str)
+  _G.__luacache.used_mpack = false
   if str == nil or #str == 0 then
     return {}
   end

--- a/lua/impatient/cachepack.lua
+++ b/lua/impatient/cachepack.lua
@@ -1,0 +1,88 @@
+local ffi = require('ffi')
+
+local M = {}
+
+-- using double for packing/unpacking numbers has no conversion overhead
+local c_double = ffi.typeof("double[1]")
+local sizeof_c_double = ffi.sizeof("double")
+
+local OutputBuffer = {}
+
+function OutputBuffer.create() return {} end
+
+function OutputBuffer.write_number(buf, num)
+  buf[#buf+1] = ffi.string(c_double(num), sizeof_c_double)
+end
+
+function OutputBuffer.write_string(buf, str)
+  OutputBuffer.write_number(buf, #str)
+  buf[#buf+1] = str
+end
+
+function OutputBuffer.to_string(buf)
+  return table.concat(buf)
+end
+
+local InputBuffer = {}
+
+function InputBuffer.create(str)
+  return {
+    ptr = ffi.new("const char[?]", #str, str),
+    pos = 0,
+    size = #str
+  }
+end
+
+function InputBuffer.read_number(buf)
+  if (buf.size < buf.pos) then error("buffer access violation") end
+  local res = ffi.cast("double*", buf.ptr + buf.pos)[0]
+  buf.pos = buf.pos + sizeof_c_double
+  return res
+end
+
+function InputBuffer.read_string(buf)
+  local len = InputBuffer.read_number(buf)
+  local res = ffi.string(buf.ptr + buf.pos, len)
+  buf.pos = buf.pos + len
+
+  return res
+end
+
+function M.pack(cache)
+  local total_keys = vim.tbl_count(cache)
+  local buf = OutputBuffer.create()
+
+  OutputBuffer.write_number(buf, total_keys)
+  for k,v in pairs(cache) do
+    OutputBuffer.write_string(buf, k)
+    OutputBuffer.write_string(buf, v[1] or "")
+    OutputBuffer.write_number(buf, v[2] or 0)
+    OutputBuffer.write_string(buf, v[3] or "")
+  end
+
+  return OutputBuffer.to_string(buf)
+end
+
+function M.unpack(str)
+  if str == nil or #str == 0 then
+    return {}
+  end
+
+  local buf = InputBuffer.create(str)
+  local cache = {}
+
+  local total_keys = InputBuffer.read_number(buf)
+  for _ = 1, total_keys do
+    local k = InputBuffer.read_string(buf)
+    local v = {
+      InputBuffer.read_string(buf),
+      InputBuffer.read_number(buf),
+      InputBuffer.read_string(buf)
+    }
+    cache[k] = v
+  end
+
+  return cache
+end
+
+return M

--- a/test/impatient_spec.lua
+++ b/test/impatient_spec.lua
@@ -131,7 +131,7 @@ describe('impatient', function()
       exp1[#exp1+1] = v
     end
 
-    it('using mpack', function()
+    it('creates cache using mpack', function()
       os.execute[[rm -rf scratch/cache]]
       exec_lua("_G.use_cachepack = false")
       exec_lua([[require('impatient')]])
@@ -144,7 +144,7 @@ describe('impatient', function()
       eq(true, exec_lua("return _G.__luacache.used_mpack"))
     end)
 
-    it('using cachepack', function()
+    it('creates cache using cachepack', function()
       os.execute[[rm -rf scratch/cache]]
       exec_lua([[require('impatient')]])
       local cachefile = exec_lua("return _G.__luacache.path")
@@ -172,40 +172,49 @@ describe('impatient', function()
       cmd [[set packpath=]]
     end
 
-    it('using mpack', function()
-      exec_lua("_G.use_cachepack = false")
-      refresh_cache()
+    describe('using mpack', function()
+      before_each(function()
+        exec_lua("_G.use_cachepack = false")
+        refresh_cache()
+      end)
 
-      exec_lua("_G.use_cachepack = false")
-      exec_lua([[require('impatient')]])
-      local cachefile = exec_lua("return _G.__luacache.path")
-      exec_lua([[require('plugins')]])
+      it('loads', function()
+        exec_lua("_G.use_cachepack = false")
+        exec_lua([[require('impatient')]])
+        local cachefile = exec_lua("return _G.__luacache.path")
+        exec_lua([[require('plugins')]])
 
-      exec_lua("_G.__luacache.save_cache()")
+        exec_lua("_G.__luacache.save_cache()")
 
-      eq({
-        'Loading cache file scratch/cache/nvim/luacache',
-      },
-        exec_lua("return _G.__luacache.log")
-      )
-      eq(true, exec_lua("return _G.__luacache.used_mpack"))
+        eq({
+          'Loading cache file scratch/cache/nvim/luacache',
+        },
+          exec_lua("return _G.__luacache.log")
+        )
+        eq(true, exec_lua("return _G.__luacache.used_mpack"))
+      end)
     end)
 
-    it('using cachepack', function()
-      refresh_cache()
+    describe('using cachepack', function()
+      before_each(function()
+        refresh_cache()
+      end)
 
-      exec_lua([[require('impatient')]])
-      local cachefile = exec_lua("return _G.__luacache.path")
-      exec_lua([[require('plugins')]])
+      it('loads', function()
 
-      exec_lua("_G.__luacache.save_cache()")
+        exec_lua([[require('impatient')]])
+        local cachefile = exec_lua("return _G.__luacache.path")
+        exec_lua([[require('plugins')]])
 
-      eq({
-        'Loading cache file scratch/cache/nvim/luacache',
-      },
-        exec_lua("return _G.__luacache.log")
-      )
-      eq(false, exec_lua("return _G.__luacache.used_mpack"))
+        exec_lua("_G.__luacache.save_cache()")
+
+        eq({
+          'Loading cache file scratch/cache/nvim/luacache',
+        },
+          exec_lua("return _G.__luacache.log")
+        )
+        eq(false, exec_lua("return _G.__luacache.used_mpack"))
+      end)
     end)
   end)
 

--- a/test/impatient_spec.lua
+++ b/test/impatient_spec.lua
@@ -17,13 +17,7 @@ describe('impatient', function()
     exec_lua([[require('plugins')]])
   end)
 
-  it('run without cache', function()
-    os.execute[[rm -rf scratch/cache]]
-    exec_lua([[require('impatient')]])
-    local cachefile = exec_lua("return _G.__luacache.path")
-
-    exec_lua([[require('plugins')]])
-    exec_lua("_G.__luacache.save_cache()")
+  describe('run without cache', function()
     local nvim05 = exec_lua('return vim.version().minor') == 5
     local exp = {
       'No cache for module plugins',
@@ -133,25 +127,63 @@ describe('impatient', function()
 
     -- Realign table
     local exp1 = {}
-    for k, v in pairs(exp) do
+    for _, v in pairs(exp) do
       exp1[#exp1+1] = v
     end
 
-    eq(exp1, exec_lua("return _G.__luacache.log"))
+    it('using mpack', function()
+      os.execute[[rm -rf scratch/cache]]
+      exec_lua([[require('impatient')]])
+      local cachefile = exec_lua("return _G.__luacache.path")
+      exec_lua("_G.__luacache.use_cachepack = false")
+
+      exec_lua([[require('plugins')]])
+      exec_lua("_G.__luacache.save_cache()")
+
+      eq(exp1, exec_lua("return _G.__luacache.log"))
+    end)
+
+    it('using cachepack', function()
+      os.execute[[rm -rf scratch/cache]]
+      exec_lua([[require('impatient')]])
+      local cachefile = exec_lua("return _G.__luacache.path")
+
+      exec_lua([[require('plugins')]])
+      exec_lua("_G.__luacache.save_cache()")
+
+      eq(exp1, exec_lua("return _G.__luacache.log"))
+    end)
   end)
 
-  it('run with cache', function()
-    exec_lua([[require('impatient')]])
-    local cachefile = exec_lua("return _G.__luacache.path")
-    exec_lua([[require('plugins')]])
+  describe('run with cache', function()
+    it('using mpack', function()
+      exec_lua([[require('impatient')]])
+      local cachefile = exec_lua("return _G.__luacache.path")
+      exec_lua("_G.__luacache.use_cachepack = false")
+      exec_lua([[require('plugins')]])
 
-    exec_lua("_G.__luacache.save_cache()")
+      exec_lua("_G.__luacache.save_cache()")
 
-    eq({
-      'Loading cache file scratch/cache/nvim/luacache',
-    },
-      exec_lua("return _G.__luacache.log")
-    )
+      eq({
+        'Loading cache file scratch/cache/nvim/luacache',
+      },
+        exec_lua("return _G.__luacache.log")
+      )
+    end)
+
+    it('using cachepack', function()
+      exec_lua([[require('impatient')]])
+      local cachefile = exec_lua("return _G.__luacache.path")
+      exec_lua([[require('plugins')]])
+
+      exec_lua("_G.__luacache.save_cache()")
+
+      eq({
+        'Loading cache file scratch/cache/nvim/luacache',
+      },
+        exec_lua("return _G.__luacache.log")
+      )
+    end)
   end)
 
 end)

--- a/test/impatient_spec.lua
+++ b/test/impatient_spec.lua
@@ -3,7 +3,12 @@ local helpers = require('test.functional.helpers')()
 local clear    = helpers.clear
 local exec_lua = helpers.exec_lua
 local eq       = helpers.eq
+local ok       = helpers.ok
 local cmd      = helpers.command
+
+local function module_loaded(mod)
+  return exec_lua("return _G.package.loaded['"..mod.."'] ~= nil")
+end
 
 describe('impatient', function()
   before_each(function()
@@ -141,7 +146,8 @@ describe('impatient', function()
       exec_lua("_G.__luacache.save_cache()")
 
       eq(exp1, exec_lua("return _G.__luacache.log"))
-      eq(true, exec_lua("return _G.__luacache.used_mpack"))
+      ok(module_loaded('mpack'))
+      ok(not module_loaded('impatient.cachepack'))
     end)
 
     it('creates cache using cachepack', function()
@@ -153,7 +159,8 @@ describe('impatient', function()
       exec_lua("_G.__luacache.save_cache()")
 
       eq(exp1, exec_lua("return _G.__luacache.log"))
-      eq(false, exec_lua("return _G.__luacache.used_mpack"))
+      ok(not module_loaded('mpack'))
+      ok(module_loaded('impatient.cachepack'))
     end)
   end)
 
@@ -191,7 +198,8 @@ describe('impatient', function()
         },
           exec_lua("return _G.__luacache.log")
         )
-        eq(true, exec_lua("return _G.__luacache.used_mpack"))
+        ok(module_loaded('mpack'))
+        ok(not module_loaded('impatient.cachepack'))
       end)
     end)
 
@@ -213,7 +221,8 @@ describe('impatient', function()
         },
           exec_lua("return _G.__luacache.log")
         )
-        eq(false, exec_lua("return _G.__luacache.used_mpack"))
+        ok(not module_loaded('mpack'))
+        ok(module_loaded('impatient.cachepack'))
       end)
     end)
   end)

--- a/test/impatient_spec.lua
+++ b/test/impatient_spec.lua
@@ -158,7 +158,24 @@ describe('impatient', function()
   end)
 
   describe('run with cache', function()
+    -- don't depend on state from prior tests
+    local function refresh_cache()
+      os.execute[[rm -rf scratch/cache]]
+      exec_lua([[require('impatient')]])
+      local cachefile = exec_lua("return _G.__luacache.path")
+      exec_lua([[require('plugins')]])
+      exec_lua("_G.__luacache.save_cache()")
+
+      clear()
+      cmd [[set runtimepath=$VIMRUNTIME,.,./test]]
+      cmd [[let $XDG_CACHE_HOME='scratch/cache']]
+      cmd [[set packpath=]]
+    end
+
     it('using mpack', function()
+      exec_lua("_G.use_cachepack = false")
+      refresh_cache()
+
       exec_lua("_G.use_cachepack = false")
       exec_lua([[require('impatient')]])
       local cachefile = exec_lua("return _G.__luacache.path")
@@ -175,6 +192,8 @@ describe('impatient', function()
     end)
 
     it('using cachepack', function()
+      refresh_cache()
+
       exec_lua([[require('impatient')]])
       local cachefile = exec_lua("return _G.__luacache.path")
       exec_lua([[require('plugins')]])

--- a/test/impatient_spec.lua
+++ b/test/impatient_spec.lua
@@ -133,14 +133,15 @@ describe('impatient', function()
 
     it('using mpack', function()
       os.execute[[rm -rf scratch/cache]]
+      exec_lua("_G.use_cachepack = false")
       exec_lua([[require('impatient')]])
       local cachefile = exec_lua("return _G.__luacache.path")
-      exec_lua("_G.__luacache.use_cachepack = false")
 
       exec_lua([[require('plugins')]])
       exec_lua("_G.__luacache.save_cache()")
 
       eq(exp1, exec_lua("return _G.__luacache.log"))
+      eq(true, exec_lua("return _G.__luacache.used_mpack"))
     end)
 
     it('using cachepack', function()
@@ -152,14 +153,15 @@ describe('impatient', function()
       exec_lua("_G.__luacache.save_cache()")
 
       eq(exp1, exec_lua("return _G.__luacache.log"))
+      eq(false, exec_lua("return _G.__luacache.used_mpack"))
     end)
   end)
 
   describe('run with cache', function()
     it('using mpack', function()
+      exec_lua("_G.use_cachepack = false")
       exec_lua([[require('impatient')]])
       local cachefile = exec_lua("return _G.__luacache.path")
-      exec_lua("_G.__luacache.use_cachepack = false")
       exec_lua([[require('plugins')]])
 
       exec_lua("_G.__luacache.save_cache()")
@@ -169,6 +171,7 @@ describe('impatient', function()
       },
         exec_lua("return _G.__luacache.log")
       )
+      eq(true, exec_lua("return _G.__luacache.used_mpack"))
     end)
 
     it('using cachepack', function()
@@ -183,6 +186,7 @@ describe('impatient', function()
       },
         exec_lua("return _G.__luacache.log")
       )
+      eq(false, exec_lua("return _G.__luacache.used_mpack"))
     end)
   end)
 

--- a/test/lua/plugins.lua
+++ b/test/lua/plugins.lua
@@ -1,6 +1,6 @@
 
 local init = {
-  ['neovim/nvim-lspconfig']       = '2f026f21',
+  ['neovim/nvim-lspconfig']       = 'cbd7c915',
   ['nvim-lua/plenary.nvim']       = '06266e7b',
   ['nvim-lua/telescope.nvim']     = 'ac42f0c2',
   ['lewis6991/gitsigns.nvim']     = 'daa233aa',


### PR DESCRIPTION
I've created a module that serializes and deserializes the cache using only LuaJIT's FFI and no requirement of `mpack`.

It is usually as fast or sometimes faster than `mpack`.

This PR makes it the default with the ability to load using `mpack` by using `_G.use_cachepack = true` before `impatient.nvim` is setup.

---

I think it would be reasonable to drop the `mpack` requirement if testing goes well among other users, that way we can revert the tests to the original ones.