### PR TITLE
Use vim.mpack by default

### DIFF
--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -16,87 +16,15 @@ local M = {
   log = {}
 }
 
-_G.use_cachepack = _G.use_cachepack ~= false
+if _G.use_cachepack == nil then
+  _G.use_cachepack = not vim.mpack
+end
 
 _G.__luacache = M
 
-local ffi = require('ffi')
-
--- using double for packing/unpacking numbers has no conversion overhead
-local sizeof_c_double = ffi.sizeof("double")
-local c_double = ffi.typeof("double[1]")
-
-local CachePack = {}
-
-function CachePack.pack(cache)
-  local buf = {}
-
-  local function write_number(num)
-    buf[#buf+1] = ffi.string(c_double(num), sizeof_c_double)
-  end
-
-  local function write_string(str)
-    write_number(#str)
-    buf[#buf+1] = str
-  end
-
-  local total_keys = vim.tbl_count(cache)
-
-  write_number(total_keys)
-  for k,v in pairs(cache) do
-    write_string(k)
-    write_string(v[1] or "")
-    write_number(v[2] or 0)
-    write_string(v[3] or "")
-  end
-
-  return table.concat(buf)
-end
-
-function CachePack.unpack(str)
-  if str == nil or #str == 0 then
-    return {}
-  end
-
-  local buf = ffi.new("const char[?]", #str, str)
-  local buf_pos = 0
-
-  local function read_number()
-    if (buf_pos > #str) then
-      error("buffer access violation")
-    end
-    local res = ffi.cast("double*", buf + buf_pos)[0]
-    buf_pos = buf_pos + sizeof_c_double
-    return res
-  end
-
-  local function read_string()
-    local len = read_number()
-    local res = ffi.string(buf + buf_pos, len)
-    buf_pos = buf_pos + len
-    return res
-  end
-
-  local cache = {}
-
-  local total_keys = read_number()
-  for _ = 1, total_keys do
-    local k = read_string()
-    cache[k] = {
-      read_string(),
-      read_number(),
-      read_string()
-    }
-  end
-
-  return cache
-end
-
 local function load_mpack()
-  local has_builtin_mpack, mpack_mod = pcall(require, 'mpack')
-
-  if has_builtin_mpack then
-    return mpack_mod
+  if vim.mpack then
+    return vim.mpack
   end
 
   local has_packer, packer_luarocks = pcall(require, 'packer.luarocks')
@@ -107,7 +35,7 @@ local function load_mpack()
   return require('mpack')
 end
 
-local mpack = _G.use_cachepack and CachePack or load_mpack()
+local mpack = _G.use_cachepack and require('impatient.cachepack') or load_mpack()
 
 local function log(...)
   M.log[#M.log+1] = table.concat({string.format(...)}, ' ')

--- a/lua/impatient/cachepack.lua
+++ b/lua/impatient/cachepack.lua
@@ -1,0 +1,73 @@
+local ffi = require('ffi')
+
+-- using double for packing/unpacking numbers has no conversion overhead
+local sizeof_c_double = ffi.sizeof("double")
+local c_double = ffi.typeof("double[1]")
+
+local CachePack = {}
+
+function CachePack.pack(cache)
+  local buf = {}
+
+  local function write_number(num)
+    buf[#buf+1] = ffi.string(c_double(num), sizeof_c_double)
+  end
+
+  local function write_string(str)
+    write_number(#str)
+    buf[#buf+1] = str
+  end
+
+  local total_keys = vim.tbl_count(cache)
+
+  write_number(total_keys)
+  for k,v in pairs(cache) do
+    write_string(k)
+    write_string(v[1] or "")
+    write_number(v[2] or 0)
+    write_string(v[3] or "")
+  end
+
+  return table.concat(buf)
+end
+
+function CachePack.unpack(str)
+  if str == nil or #str == 0 then
+    return {}
+  end
+
+  local buf = ffi.new("const char[?]", #str, str)
+  local buf_pos = 0
+
+  local function read_number()
+    if (buf_pos > #str) then
+      error("buffer access violation")
+    end
+    local res = ffi.cast("double*", buf + buf_pos)[0]
+    buf_pos = buf_pos + sizeof_c_double
+    return res
+  end
+
+  local function read_string()
+    local len = read_number()
+    local res = ffi.string(buf + buf_pos, len)
+    buf_pos = buf_pos + len
+    return res
+  end
+
+  local cache = {}
+
+  local total_keys = read_number()
+  for _ = 1, total_keys do
+    local k = read_string()
+    cache[k] = {
+      read_string(),
+      read_number(),
+      read_string()
+    }
+  end
+
+  return cache
+end
+
+return CachePack

--- a/test/impatient_spec.lua
+++ b/test/impatient_spec.lua
@@ -6,8 +6,121 @@ local eq       = helpers.eq
 local ok       = helpers.ok
 local cmd      = helpers.command
 
-local function module_loaded(mod)
-  return exec_lua("return _G.package.loaded['"..mod.."'] ~= nil")
+local gen_exp = function(use_cachepack)
+  local nvim05 = exec_lua('return vim.version().minor') == 5
+  local exp = {
+    'No cache for module plugins',
+    'Creating cache for module plugins',
+    'No cache for module telescope',
+    'Creating cache for module telescope',
+    'No cache for module telescope._extensions',
+    'Creating cache for module telescope._extensions',
+    'No cache for module gitsigns',
+    'Creating cache for module gitsigns',
+    'No cache for module plenary.async.async',
+    'Creating cache for module plenary.async.async',
+    'No cache for module plenary.vararg',
+    'Creating cache for module plenary.vararg',
+    'No cache for module plenary.vararg.rotate',
+    'Creating cache for module plenary.vararg.rotate',
+    'No cache for module plenary.tbl',
+    'Creating cache for module plenary.tbl',
+    'No cache for module plenary.errors',
+    'Creating cache for module plenary.errors',
+    'No cache for module plenary.functional',
+    'Creating cache for module plenary.functional',
+    'No cache for module plenary.async.util',
+    'Creating cache for module plenary.async.util',
+    'No cache for module plenary.async.control',
+    'Creating cache for module plenary.async.control',
+    'No cache for module plenary.async.structs',
+    'Creating cache for module plenary.async.structs',
+    'No cache for module gitsigns.status',
+    'Creating cache for module gitsigns.status',
+    'No cache for module gitsigns.git',
+    'Creating cache for module gitsigns.git',
+    'No cache for module plenary.job',
+    'Creating cache for module plenary.job',
+    'No cache for module gitsigns.debug',
+    'Creating cache for module gitsigns.debug',
+    'No cache for module gitsigns.util',
+    'Creating cache for module gitsigns.util',
+    'No cache for module gitsigns.hunks',
+    'Creating cache for module gitsigns.hunks',
+    'No cache for module gitsigns.signs',
+    'Creating cache for module gitsigns.signs',
+    'No cache for module gitsigns.config',
+    'Creating cache for module gitsigns.config',
+    'No cache for module gitsigns.manager',
+    'Creating cache for module gitsigns.manager',
+    'No cache for module gitsigns.cache',
+    'Creating cache for module gitsigns.cache',
+    'No cache for module gitsigns.debounce',
+    'Creating cache for module gitsigns.debounce',
+    'No cache for module gitsigns.highlight',
+    'Creating cache for module gitsigns.highlight',
+    'No cache for module spellsitter',
+    'Creating cache for module spellsitter',
+    'No cache for module vim.treesitter.query',
+    'Creating cache for module vim.treesitter.query',
+    'No cache for module vim.treesitter.language',
+    'Creating cache for module vim.treesitter.language',
+    'No cache for module vim.treesitter',
+    'Creating cache for module vim.treesitter',
+    'No cache for module vim.treesitter.languagetree',
+    'Creating cache for module vim.treesitter.languagetree',
+    'No cache for module colorizer',
+    'Creating cache for module colorizer',
+    'No cache for module colorizer/nvim',
+    'Creating cache for module colorizer/nvim',
+    'No cache for module colorizer/trie',
+    'Creating cache for module colorizer/trie',
+    'No cache for module lspconfig',
+    'Creating cache for module lspconfig',
+    'No cache for module lspconfig/configs',
+    'Creating cache for module lspconfig/configs',
+    'No cache for module lspconfig/util',
+    'Creating cache for module lspconfig/util',
+    use_cachepack and 'No cache for module vim.uri' or nil,
+    use_cachepack and 'Creating cache for module vim.uri' or nil,
+    'No cache for module vim.lsp',
+    'Creating cache for module vim.lsp',
+    nvim05 and 'No cache for module vim.F' or nil,
+    nvim05 and 'Creating cache for module vim.F' or nil,
+    'No cache for module vim.lsp.handlers',
+    'Creating cache for module vim.lsp.handlers',
+    'No cache for module vim.lsp.log',
+    'Creating cache for module vim.lsp.log',
+    'No cache for module vim.lsp.protocol',
+    'Creating cache for module vim.lsp.protocol',
+    'No cache for module vim.lsp.util',
+    'Creating cache for module vim.lsp.util',
+    'No cache for module vim.highlight',
+    'Creating cache for module vim.highlight',
+    'No cache for module vim.lsp.buf',
+    'Creating cache for module vim.lsp.buf',
+    'No cache for module vim.lsp.rpc',
+    'Creating cache for module vim.lsp.rpc',
+    'No cache for module vim.lsp.diagnostic',
+    'Creating cache for module vim.lsp.diagnostic',
+    'No cache for module vim.lsp.codelens',
+    'Creating cache for module vim.lsp.codelens',
+    'No cache for module bufferline',
+    'Creating cache for module bufferline',
+    'No cache for module bufferline.constants',
+    'Creating cache for module bufferline.constants',
+    'No cache for module bufferline.utils',
+    'Creating cache for module bufferline.utils',
+    'Updating cache file: scratch/cache/nvim/luacache'
+  }
+
+  -- Realign table
+  local exp1 = {}
+  for _, v in pairs(exp) do
+    exp1[#exp1+1] = v
+  end
+
+  return exp1
 end
 
 describe('impatient', function()
@@ -22,205 +135,38 @@ describe('impatient', function()
     exec_lua([[require('plugins')]])
   end)
 
-  describe('run without cache', function()
-    local nvim05 = exec_lua('return vim.version().minor') == 5
-    local exp = {
-      'No cache for module plugins',
-      'Creating cache for module plugins',
-      'No cache for module telescope',
-      'Creating cache for module telescope',
-      'No cache for module telescope._extensions',
-      'Creating cache for module telescope._extensions',
-      'No cache for module gitsigns',
-      'Creating cache for module gitsigns',
-      'No cache for module plenary.async.async',
-      'Creating cache for module plenary.async.async',
-      'No cache for module plenary.vararg',
-      'Creating cache for module plenary.vararg',
-      'No cache for module plenary.vararg.rotate',
-      'Creating cache for module plenary.vararg.rotate',
-      'No cache for module plenary.tbl',
-      'Creating cache for module plenary.tbl',
-      'No cache for module plenary.errors',
-      'Creating cache for module plenary.errors',
-      'No cache for module plenary.functional',
-      'Creating cache for module plenary.functional',
-      'No cache for module plenary.async.util',
-      'Creating cache for module plenary.async.util',
-      'No cache for module plenary.async.control',
-      'Creating cache for module plenary.async.control',
-      'No cache for module plenary.async.structs',
-      'Creating cache for module plenary.async.structs',
-      'No cache for module gitsigns.status',
-      'Creating cache for module gitsigns.status',
-      'No cache for module gitsigns.git',
-      'Creating cache for module gitsigns.git',
-      'No cache for module plenary.job',
-      'Creating cache for module plenary.job',
-      'No cache for module gitsigns.debug',
-      'Creating cache for module gitsigns.debug',
-      'No cache for module gitsigns.util',
-      'Creating cache for module gitsigns.util',
-      'No cache for module gitsigns.hunks',
-      'Creating cache for module gitsigns.hunks',
-      'No cache for module gitsigns.signs',
-      'Creating cache for module gitsigns.signs',
-      'No cache for module gitsigns.config',
-      'Creating cache for module gitsigns.config',
-      'No cache for module gitsigns.manager',
-      'Creating cache for module gitsigns.manager',
-      'No cache for module gitsigns.cache',
-      'Creating cache for module gitsigns.cache',
-      'No cache for module gitsigns.debounce',
-      'Creating cache for module gitsigns.debounce',
-      'No cache for module gitsigns.highlight',
-      'Creating cache for module gitsigns.highlight',
-      'No cache for module spellsitter',
-      'Creating cache for module spellsitter',
-      'No cache for module vim.treesitter.query',
-      'Creating cache for module vim.treesitter.query',
-      'No cache for module vim.treesitter.language',
-      'Creating cache for module vim.treesitter.language',
-      'No cache for module vim.treesitter',
-      'Creating cache for module vim.treesitter',
-      'No cache for module vim.treesitter.languagetree',
-      'Creating cache for module vim.treesitter.languagetree',
-      'No cache for module colorizer',
-      'Creating cache for module colorizer',
-      'No cache for module colorizer/nvim',
-      'Creating cache for module colorizer/nvim',
-      'No cache for module colorizer/trie',
-      'Creating cache for module colorizer/trie',
-      'No cache for module lspconfig',
-      'Creating cache for module lspconfig',
-      'No cache for module lspconfig/configs',
-      'Creating cache for module lspconfig/configs',
-      'No cache for module lspconfig/util',
-      'Creating cache for module lspconfig/util',
-      'No cache for module vim.uri',
-      'Creating cache for module vim.uri',
-      'No cache for module vim.lsp',
-      'Creating cache for module vim.lsp',
-      nvim05 and 'No cache for module vim.F' or nil,
-      nvim05 and 'Creating cache for module vim.F' or nil,
-      'No cache for module vim.lsp.handlers',
-      'Creating cache for module vim.lsp.handlers',
-      'No cache for module vim.lsp.log',
-      'Creating cache for module vim.lsp.log',
-      'No cache for module vim.lsp.protocol',
-      'Creating cache for module vim.lsp.protocol',
-      'No cache for module vim.lsp.util',
-      'Creating cache for module vim.lsp.util',
-      'No cache for module vim.highlight',
-      'Creating cache for module vim.highlight',
-      'No cache for module vim.lsp.buf',
-      'Creating cache for module vim.lsp.buf',
-      'No cache for module vim.lsp.rpc',
-      'Creating cache for module vim.lsp.rpc',
-      'No cache for module vim.lsp.diagnostic',
-      'Creating cache for module vim.lsp.diagnostic',
-      'No cache for module vim.lsp.codelens',
-      'Creating cache for module vim.lsp.codelens',
-      'No cache for module bufferline',
-      'Creating cache for module bufferline',
-      'No cache for module bufferline.constants',
-      'Creating cache for module bufferline.constants',
-      'No cache for module bufferline.utils',
-      'Creating cache for module bufferline.utils',
-      'Updating cache file: scratch/cache/nvim/luacache'
-    }
-
-    -- Realign table
-    local exp1 = {}
-    for _, v in pairs(exp) do
-      exp1[#exp1+1] = v
+  local function tests(use_cachepack)
+    local function run()
+      exec_lua([[
+        _G.use_cachepack = ...
+        require('impatient')
+        require('plugins')
+        _G.__luacache.save_cache()
+      ]], use_cachepack)
     end
 
-    it('creates cache using mpack', function()
+    it('creates cache', function()
       os.execute[[rm -rf scratch/cache]]
-      exec_lua("_G.use_cachepack = false")
-      exec_lua([[require('impatient')]])
-      local cachefile = exec_lua("return _G.__luacache.path")
-
-      exec_lua([[require('plugins')]])
-      exec_lua("_G.__luacache.save_cache()")
-
-      eq(exp1, exec_lua("return _G.__luacache.log"))
-      ok(module_loaded('mpack'))
+      run()
+      eq(gen_exp(use_cachepack), exec_lua("return _G.__luacache.log"))
     end)
 
-    it('creates cache using cachepack', function()
-      os.execute[[rm -rf scratch/cache]]
-      exec_lua([[require('impatient')]])
-      local cachefile = exec_lua("return _G.__luacache.path")
+    it('loads cache', function()
+      run()
 
-      exec_lua([[require('plugins')]])
-      exec_lua("_G.__luacache.save_cache()")
+      eq({ 'Loading cache file scratch/cache/nvim/luacache' },
+        exec_lua("return _G.__luacache.log"))
 
-      eq(exp1, exec_lua("return _G.__luacache.log"))
-      ok(not module_loaded('mpack'))
+      ok(use_cachepack == exec_lua("return _G.package.loaded['impatient.cachepack'] ~= nil"))
     end)
+  end
+
+  describe('using mpack', function()
+    tests(false)
   end)
 
-  describe('run with cache', function()
-    -- don't depend on state from prior tests
-    local function refresh_cache()
-      os.execute[[rm -rf scratch/cache]]
-      exec_lua([[require('impatient')]])
-      local cachefile = exec_lua("return _G.__luacache.path")
-      exec_lua([[require('plugins')]])
-      exec_lua("_G.__luacache.save_cache()")
-
-      clear()
-      cmd [[set runtimepath=$VIMRUNTIME,.,./test]]
-      cmd [[let $XDG_CACHE_HOME='scratch/cache']]
-      cmd [[set packpath=]]
-    end
-
-    describe('using mpack', function()
-      before_each(function()
-        exec_lua("_G.use_cachepack = false")
-        refresh_cache()
-      end)
-
-      it('loads', function()
-        exec_lua("_G.use_cachepack = false")
-        exec_lua([[require('impatient')]])
-        local cachefile = exec_lua("return _G.__luacache.path")
-        exec_lua([[require('plugins')]])
-
-        exec_lua("_G.__luacache.save_cache()")
-
-        eq({
-          'Loading cache file scratch/cache/nvim/luacache',
-        },
-          exec_lua("return _G.__luacache.log")
-        )
-        ok(module_loaded('mpack'))
-      end)
-    end)
-
-    describe('using cachepack', function()
-      before_each(function()
-        refresh_cache()
-      end)
-
-      it('loads', function()
-
-        exec_lua([[require('impatient')]])
-        local cachefile = exec_lua("return _G.__luacache.path")
-        exec_lua([[require('plugins')]])
-
-        exec_lua("_G.__luacache.save_cache()")
-
-        eq({
-          'Loading cache file scratch/cache/nvim/luacache',
-        },
-          exec_lua("return _G.__luacache.log")
-        )
-        ok(not module_loaded('mpack'))
-      end)
-    end)
+  describe('using cachepack', function()
+    tests(true)
   end)
 
 end)


### PR DESCRIPTION
The precedence is now:
1. `vim.mpack`
2. `impatient.cachepack`
3. `require('mpack')`

Additionally:
- Put cachepack back into its own module.
- Restructure tests
