### PR TITLE
profile: set buffer nomodifiable

### DIFF
--- a/lua/impatient/profile.lua
+++ b/lua/impatient/profile.lua
@@ -110,6 +110,7 @@ function M.print_profile(profile)
   local bufnr = api.nvim_create_buf(false, false)
   api.nvim_buf_set_lines(bufnr, 0, 0, false, lines)
   api.nvim_buf_set_option(bufnr, 'buftype', 'nofile')
+  api.nvim_buf_set_option(bufnr, "modifiable", false)
   api.nvim_buf_set_name(bufnr, 'Impatient Profile Report')
   api.nvim_set_current_buf(bufnr)
 end


### PR DESCRIPTION
Figured it'd make sense to not allow modifying this buffer, by default.