### PR TITLE
fix: adapt to upstream rename of vim.mpack.*

### DIFF
--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -240,7 +240,7 @@ function M.save_cache()
   if M.dirty then
     log('Updating cache file: %s', M.path)
     local f = io.open(M.path, 'w+b')
-    f:write(mpack.pack(M.cache))
+    f:write(mpack.encode(M.cache))
     f:flush()
     M.dirty = false
   end
@@ -272,7 +272,7 @@ local function setup()
     local f = io.open(M.path, 'rb')
     local ok
     ok, M.cache = pcall(function()
-      return mpack.unpack(f:read'*a')
+      return mpack.decode(f:read'*a')
     end)
 
     if not ok then

--- a/lua/impatient/cachepack.lua
+++ b/lua/impatient/cachepack.lua
@@ -10,7 +10,7 @@ local c_sizeof_number_t = ffi.sizeof "number_t"
 
 local CachePack = {}
 
-function CachePack.pack(cache)
+function CachePack.encode(cache)
   local buf = {}
 
   local function write_number(num)
@@ -35,7 +35,7 @@ function CachePack.pack(cache)
   return table.concat(buf)
 end
 
-function CachePack.unpack(str)
+function CachePack.decode(str)
   if str == nil or #str == 0 then
     return {}
   end


### PR DESCRIPTION
`vim.mpack.pack` -> `vim.mpack.encode`
`vim.mpack.unpack` -> `vim.mpack.decode`
https://github.com/neovim/neovim/pull/16175

closes #36