### PR TITLE
break!: remove Neovim v0.6 compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        neovim_branch: ['v0.6.0', 'master']
+        neovim_branch: ['v0.7.0', 'master']
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See configuration below for more details.
 
 ## Requirements
 
-- Neovim v0.6.0
+- Neovim v0.7
 
 ## Installation
 

--- a/test/impatient_spec.lua
+++ b/test/impatient_spec.lua
@@ -5,10 +5,10 @@ local exec_lua = helpers.exec_lua
 local eq       = helpers.eq
 local cmd      = helpers.command
 
-local nvim06
+local nvim07
 
 local function gen_exp(exp)
-  local neovim_dir = nvim06 and 'neovim-v0.6.0' or 'neovim-master'
+  local neovim_dir = nvim07 and 'neovim-v0.7.0' or 'neovim-master'
   local cwd = exec_lua('return vim.loop.cwd()')
 
   local exp1 = {}
@@ -133,9 +133,6 @@ local gen_exp_cold = function()
     'Creating cache for module lspconfig/util',
     'No cache for path {CWD}/scratch/nvim-lspconfig/lua/lspconfig/util.lua',
     'Creating cache for path {CWD}/scratch/nvim-lspconfig/lua/lspconfig/util.lua',
-    nvim06 and 'Creating cache for module vim/uri',
-    nvim06 and 'No cache for path {CWD}/{NVIM}/runtime/lua/vim/uri.lua',
-    nvim06 and 'Creating cache for path {CWD}/{NVIM}/runtime/lua/vim/uri.lua',
     'Creating cache for module vim/lsp',
     'No cache for path {CWD}/{NVIM}/runtime/lua/vim/lsp.lua',
     'Creating cache for path {CWD}/{NVIM}/runtime/lua/vim/lsp.lua',
@@ -226,7 +223,6 @@ local gen_exp_hot = function()
     'Loaded cache for path {CWD}/scratch/nvim-lspconfig/lua/lspconfig.lua',
     'Loaded cache for path {CWD}/scratch/nvim-lspconfig/lua/lspconfig/configs.lua',
     'Loaded cache for path {CWD}/scratch/nvim-lspconfig/lua/lspconfig/util.lua',
-    nvim06 and 'Loaded cache for path {CWD}/{NVIM}/runtime/lua/vim/uri.lua',
     'Loaded cache for path {CWD}/{NVIM}/runtime/lua/vim/lsp.lua',
     'Loaded cache for path {CWD}/{NVIM}/runtime/lua/vim/lsp/handlers.lua',
     'Loaded cache for path {CWD}/{NVIM}/runtime/lua/vim/lsp/log.lua',
@@ -248,7 +244,7 @@ end
 describe('impatient', function()
   local function reset()
     clear()
-    nvim06 = exec_lua('return vim.version().minor') == 6
+    nvim07 = exec_lua('return vim.version().minor') == 7
     cmd [[set runtimepath=$VIMRUNTIME,.,./test]]
     cmd [[let $XDG_CACHE_HOME='scratch/cache']]
     cmd [[set packpath=]]


### PR DESCRIPTION
- Update to autocmd API
- Update to user command API
- Fix profiling for unloaded modules
- List unloaded modules in profile report
- Validate the resolved module path against 'runtimepath'
