### PR TITLE
Corrected path separator for windows

### DIFF
--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -25,9 +25,7 @@ local std_dirs = {
 
 local function modpath_mangle(modpath)
   for name, dir in pairs(std_dirs) do
-    if (dir ~= 'nil') then
-      modpath = modpath:gsub(dir, name)
-    end
+    modpath = modpath:gsub(dir, name)
   end
   return modpath
 end

--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -25,7 +25,9 @@ local std_dirs = {
 
 local function modpath_mangle(modpath)
   for name, dir in pairs(std_dirs) do
-    modpath = modpath:gsub(dir, name)
+    if (dir ~= 'nil') then
+      modpath = modpath:gsub(dir, name)
+    end
   end
   return modpath
 end

--- a/lua/impatient/profile.lua
+++ b/lua/impatient/profile.lua
@@ -1,5 +1,12 @@
 local M = {}
 
+local sep = ''
+if (jit.os == 'Windows') then
+  sep = '\\'
+else
+  sep = '/'
+end
+
 local api, uv = vim.api, vim.loop
 
 local function load_buffer(title, lines)
@@ -56,7 +63,7 @@ function M.print_profile(I, std_dirs)
   local unloaded = {}
 
   for module, m in pairs(mod_profile) do
-    local module_dot = module:gsub('/', '.')
+    local module_dot = module:gsub(sep, '.')
     m.module = module_dot
 
     if not package.loaded[module_dot] and not package.loaded[module] then
@@ -222,7 +229,7 @@ M.setup = function(profile)
   local _require = require
 
   require = function(mod)
-    local basename = mod:gsub('%.', '/')
+    local basename = mod:gsub('%.', sep)
     if not profile[basename] then
       profile[basename] = {}
       profile[basename].resolve_start = uv.hrtime()
@@ -236,7 +243,7 @@ M.setup = function(profile)
   for i = 1, #pl do
     local l = pl[i]
     pl[i] = function(mod)
-      local basename = mod:gsub('%.', '/')
+      local basename = mod:gsub('%.', sep)
       profile[basename].loader_guess = i == 1 and 'preloader' or 'loader #'..i
       return l(mod)
     end

--- a/lua/impatient/profile.lua
+++ b/lua/impatient/profile.lua
@@ -13,6 +13,13 @@ local function load_buffer(title, lines)
   api.nvim_set_current_buf(bufnr)
 end
 
+local sep = ''
+if (jit.os == 'Windows') then
+  sep = '\\'
+else
+  sep = '/'
+end
+
 local function time_tostr(x)
   if x == 0 then
     return '?'
@@ -56,7 +63,7 @@ function M.print_profile(I, std_dirs)
   local unloaded = {}
 
   for module, m in pairs(mod_profile) do
-    local module_dot = module:gsub('/', '.')
+    local module_dot = module:gsub(sep, '.')
     m.module = module_dot
 
     if not package.loaded[module_dot] and not package.loaded[module] then
@@ -222,7 +229,7 @@ M.setup = function(profile)
   local _require = require
 
   require = function(mod)
-    local basename = mod:gsub('%.', '/')
+    local basename = mod:gsub('%.', sep)
     if not profile[basename] then
       profile[basename] = {}
       profile[basename].resolve_start = uv.hrtime()
@@ -236,7 +243,7 @@ M.setup = function(profile)
   for i = 1, #pl do
     local l = pl[i]
     pl[i] = function(mod)
-      local basename = mod:gsub('%.', '/')
+      local basename = mod:gsub('%.', sep)
       profile[basename].loader_guess = i == 1 and 'preloader' or 'loader #'..i
       return l(mod)
     end

--- a/lua/impatient/profile.lua
+++ b/lua/impatient/profile.lua
@@ -13,13 +13,6 @@ local function load_buffer(title, lines)
   api.nvim_set_current_buf(bufnr)
 end
 
-local sep = ''
-if (jit.os == 'Windows') then
-  sep = '\\'
-else
-  sep = '/'
-end
-
 local function time_tostr(x)
   if x == 0 then
     return '?'
@@ -63,7 +56,7 @@ function M.print_profile(I, std_dirs)
   local unloaded = {}
 
   for module, m in pairs(mod_profile) do
-    local module_dot = module:gsub(sep, '.')
+    local module_dot = module:gsub('/', '.')
     m.module = module_dot
 
     if not package.loaded[module_dot] and not package.loaded[module] then
@@ -229,7 +222,7 @@ M.setup = function(profile)
   local _require = require
 
   require = function(mod)
-    local basename = mod:gsub('%.', sep)
+    local basename = mod:gsub('%.', '/')
     if not profile[basename] then
       profile[basename] = {}
       profile[basename].resolve_start = uv.hrtime()
@@ -243,7 +236,7 @@ M.setup = function(profile)
   for i = 1, #pl do
     local l = pl[i]
     pl[i] = function(mod)
-      local basename = mod:gsub('%.', sep)
+      local basename = mod:gsub('%.', '/')
       profile[basename].loader_guess = i == 1 and 'preloader' or 'loader #'..i
       return l(mod)
     end


### PR DESCRIPTION
When I run LuaCacheLog now (on windows) it still shows a forward before lua directory only.. I could fix the rest to backslashes but not that one. I haven't learnt any lua outside of configuring neovim. Please help fixing that one too.

![image](https://user-images.githubusercontent.com/95736269/185668367-c25d1d77-1d15-4ccc-b5ce-c62de38f0c26.png)
