### PR TITLE
Use vim.loop.os_uname().sysname instead of jit.os

### DIFF
--- a/lua/impatient.lua
+++ b/lua/impatient.lua
@@ -9,12 +9,7 @@ local loadlib = package.loadlib
 
 local std_cache = vim.fn.stdpath('cache')
 
-local sep = ''
-if (jit.os == 'Windows') then
-  sep = '\\'
-else
-  sep = '/'
-end
+local sep = vim.loop.os_uname().sysname:match('Windows') and '\\' or '/'
 
 local std_dirs = {
   ['<APPDIR>']     = os.getenv('APPDIR'),

--- a/lua/impatient/profile.lua
+++ b/lua/impatient/profile.lua
@@ -1,11 +1,6 @@
 local M = {}
 
-local sep = ''
-if (jit.os == 'Windows') then
-  sep = '\\'
-else
-  sep = '/'
-end
+local sep = vim.loop.os_uname().sysname:match('Windows') and '\\' or '/'
 
 local api, uv = vim.api, vim.loop
 


### PR DESCRIPTION
Neovim on ARM is shipped with Lua5.1 instead of LuaJIT so this patch fix this compatibility