### PR TITLE
Leave a hint on safe require

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ init.lua:
 require('impatient')
 ```
 
+_Or `pcall(require, 'impatient')` to avoid failure when `impatient` is not yet installed yet._
+
 init.vim:
 
 ```viml


### PR DESCRIPTION
`pcall(require, 'impatient')` should be mentioned as `require` should be called before `packer` setup which result in no `impatient` installed yet situation for the fresh cloned dotfiles.