### PR TITLE
feat: workflow for publishing to luarocks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: "release"
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v4
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          detailed_description: |
+            This plugin does several things to speed loading Lua modules and files.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # impatient.nvim
 
 [![CI](https://github.com/lewis6991/impatient.nvim/workflows/CI/badge.svg?branch=main)](https://github.com/lewis6991/impatient.nvim/actions?query=workflow%3ACI)
+[![LuaRocks](https://img.shields.io/luarocks/v/lewis6991/impatient.nvim?logo=lua&color=purple)](https://luarocks.org/modules/lewis6991/impatient.nvim)
 
 Speed up loading Lua modules in Neovim to improve startup time.
 


### PR DESCRIPTION
### Summary

This PR is part of a push to get Neovim plugins on LuaRocks.

* See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) by @teto.

### Things done:

* Add a workflow that publishes tags to LuaRocks.
* Add a LuaRocks badge to the readme (assuming the existence of a `lewis6991/impatient.nvim` package).

### Notes

* For the release workflow to work, someone with a Luarocks account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
* Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` label has to be added manually, for this plugin to show up in https://luarocks.org/labels/neovim
* If you would prefer rolling releases without tags, [this is also possible](https://github.com/nvim-neorocks/luarocks-tag-release#version-optional).

__Adding the API key (screen shot)__
![github-add-luarocks-api-key](https://user-images.githubusercontent.com/12857160/211071297-afb129be-7a8f-4662-b282-9d52bb0286de.png)