### PR TITLE
check-file-exists-in-print-profile

### DIFF
--- a/lua/impatient/profile.lua
+++ b/lua/impatient/profile.lua
@@ -196,8 +196,10 @@ local function print_profile(I, std_dirs, impatient_time)
 
   add('Cache files:')
   for _, f in ipairs{ I.chunks.path, I.modpaths.path } do
-    local size = vim.loop.fs_stat(f).size
-    add('  %s %s', f, mem_tostr(size))
+    if vim.loop.fs_stat(f) then
+      local size = vim.loop.fs_stat(f).size
+      add('  %s %s', f, mem_tostr(size))
+    end
   end
   add('')
 


### PR DESCRIPTION
I tried to run the command "LuaCacheProfile" and I was getting this error

```lua
Error executing Lua callback: ...share/nvim/lazy/impatient.nvim/lua/impatient/profile.lua:200: attempt to index a nil value                                    
stack traceback:
        ...share/nvim/lazy/impatient.nvim/lua/impatient/profile.lua:200: in function 'print_profile'
        ...share/nvim/lazy/impatient.nvim/lua/impatient/profile.lua:327: in function <...share/nvim/lazy/impatient.nvim/lua/impatient/profile.lua:326>
```
I didn't see much through the whole code, but the one causing this problem was accessing a file that doesn't exists. so this pull request checks if the file exists or not before accessing the "size" of the file. 
> I am making this pull request to bring the issue 